### PR TITLE
Selected Traits List Object Creation Moved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-and-mint-nft-collection",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "async-sema": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,6 @@ var metadataList = [];
 var attributesList = [];
 var dnaList = new Set();
 const DNA_DELIMITER = "-";
-const selectedTraitsList = new Set();
 const HashlipsGiffer = require(`${FOLDERS.modulesDir}/HashlipsGiffer.js`);
 
 const { needsFiltration } = require('./filters');
@@ -398,6 +397,7 @@ const startCreating = async () => {
     ? console.log("Editions left to create: ", abstractedIndexes)
     : null;
   while (layerConfigIndex < layerConfigurations.length) {
+    const selectedTraitsList = new Set();
     const layers = layersSetup(
       layerConfigurations[layerConfigIndex].layersOrder
     );


### PR DESCRIPTION
Moved the selectedTraitsList set creation to the beginning of the loop for each layer configuration object instead of as a global set for all configuration items. This allows users to filtrations specifically for each layer configuration object.

Previous behaviour allowed the selected traits from one layer configuration object to affect the the maximum repeatability configuration of another layer configuration, which should not be the case as each of these settings are set at a layer configuration level, not at a global level for all layer configuration objects.

Should users require the previous functionality, then a new issue can be created where a minor rework can be done on the maximum repeatability filter along with re-working the main module.