### PR TITLE
DNA retries per DNA

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -471,12 +471,13 @@ const startCreating = async () => {
           console.log(
             `Created edition: ${abstractedIndexes[0]}, with DNA: ${sha1(
               newDna
-            )}`
+            )} (tries: ${failedCount})`
           );
         });
         dnaList.add(filterDNAOptions(newDna));
         selectedTraitsList.add(traits);
         editionCount++;
+        failedCount = 0; 
         abstractedIndexes.shift();
       } else {
         console.log("DNA exists!");


### PR DESCRIPTION
`uniqueDnaTorrance` is currently used as global maximum fail count for generating all DNAs. This makes this number dependent on the edition size. It is much more usable if this number is used as maximum try count for a single DNA.

This change resets `failedCount` when creating DNA after each successful DNA creation. It also adds a try count to the log message when a DNA was created to get a better sense on how hard it was to find a valid configuration with more complex filter rules.