### PR TITLE
Minor Bug Fix On Starting startCollectionEditionFrom Setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-and-mint-nft-collection",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "MIT",
       "dependencies": {
         "async-sema": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",

--- a/src/main.js
+++ b/src/main.js
@@ -390,7 +390,11 @@ const startCreating = async () => {
         ? _startCollectionEditionFrom > 1
           ? _startCollectionEditionFrom
           : 0
-        : _startCollectionEditionFrom ? _startCollectionEditionFrom : 1;
+        : NFT_DETAILS.startCollectionEditionFrom === '0'
+          ? 0
+          : _startCollectionEditionFrom
+            ? _startCollectionEditionFrom 
+            : 1;
     i <= layerConfigurations[layerConfigurations.length - 1].growEditionSizeTo + (_startCollectionEditionFrom > 1 && _startCollectionEditionFrom);
     i++
   ) {


### PR DESCRIPTION
A minor bug was identified when setting the startCollectionEditionFrom value to '0'.

The check that was done previously would check if startCollectionEditionFrom exists as a number, which technically is correct, however, the number '0', gets picked up as not existing. An additional check was added to cater for '0' and now all cases are generating collection numbers correctly now.