### PR TITLE
Windows 502 HTTP Response Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -14,6 +14,7 @@
         "canvas": "^2.9.0",
         "form-data": "^4.0.0",
         "gif-encoder-2": "^1.0.5",
+        "graceful-fs": "^4.2.9",
         "node-fetch": "^2.6.7",
         "puppeteer": "^13.4.1",
         "sha1": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",
@@ -51,6 +51,7 @@
     "canvas": "^2.9.0",
     "form-data": "^4.0.0",
     "gif-encoder-2": "^1.0.5",
+    "graceful-fs": "^4.2.9",
     "node-fetch": "^2.6.7",
     "puppeteer": "^13.5.0",
     "sha1": "^1.1.1",

--- a/utils/nftport/uploadMetas_directory.js
+++ b/utils/nftport/uploadMetas_directory.js
@@ -1,6 +1,6 @@
 // Load modules and constants
 const { RateLimit } = require('async-sema');
-const fs = require("fs");
+const fs = require("graceful-fs");
 const FormData = require("form-data");
 const BASEDIR = process.cwd();
 const { FOLDERS } = require(`${BASEDIR}/constants/folders.js`);


### PR DESCRIPTION
Users reported a 502 HTTP Response code error when using the uploadMetas_directory script on a Windows Operating System.

This is due to the normal fs module not handling file closures correctly. Graceful-fs has been implemented to fix this issue for Windows users.