### PR TITLE
Opensea Sell NFTs Added Metamask Account Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ If you would like to support my NFT collection, please take a look at the below.
 
 
 ### Added Opensea Selling Script
-Added a new script `utils/opensea/sell_nfts.js` that will allow users to sell NFTs between two edition numbers (inclusive) to be put up for sale if the user owns the NFTs. This functionality uses Puppeteer and Chainsafe's Dappeteer, so please use at your own discretion as you will need to make use of your seed phrase for this functionality to work. [Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42) and [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47)
+Added a new script `utils/opensea/sell_nfts.js` that will allow users to sell NFTs between two edition numbers (inclusive) to be put up for sale if the user owns the NFTs. This functionality uses Puppeteer and Chainsafe's Dappeteer, so please use at your own discretion as you will need to make use of your seed phrase for this functionality to work. [Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42), [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47) and [Feature - Opensea Polygon Script To Auto Sell NFTs Added Metamask Account Number](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/49)
 
 
 ### Added Start Collection Edition Setting
@@ -508,11 +508,11 @@ Use the  `Opensea - Refresh_Metadata Command` below to start the refresh of meta
 
 
 ### 18. Sell NFTS On Opensea
-Go to the utils/opensea/sell_nfts.js file and update the `START_EDITION`, `END_EDITION`, `NFT_PRICE`, `DROPDOWN_OPTION`, `DATE_PICK_SKIP`, `START_HOUR`, `START_MINUTE`, `END_HOUR`, `END_MINUTE` and potentially `seed` fields. Please make sure that the contract address that you are trying sell NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file as well as that the `chain` value is correct for the specific contract address.
+Go to the utils/opensea/sell_nfts.js file and update the `START_EDITION`, `END_EDITION`, `NFT_PRICE`, `DROPDOWN_OPTION`, `DATE_PICK_SKIP`, `START_HOUR`, `START_MINUTE`, `END_HOUR`, `END_MINUTE` fields. Optionally, users can also update the `METAMASK_ACCOUNT_NUMBER` and `seed` fields. Please make sure that the contract address that you are trying sell NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file (also ensure that your `METAMASK_ACCOUNT_NUMBER` is mapped correctly to the `contract_address` value on your Metamask dropdown list) as well as that the `chain` value is correct for the specific contract address.
 
 Use the  `Opensea - Sell_Nfts Command` below to start the putting each NFT edition up for sale between your start and end editions for the given price.
 
-[Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42) and [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47)
+[Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42), [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47) and [Feature - Opensea Polygon Script To Auto Sell NFTs Added Metamask Account Number](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/49)
 
 **Please read the warning very carefully within the the sell_nfts.js file with regards to the seed field.**
 **Please note that this script will only work with the Polygon network**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-and-mint-nft-collection",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/dappeteer": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",

--- a/utils/opensea/sell_nfts.js
+++ b/utils/opensea/sell_nfts.js
@@ -15,6 +15,7 @@ const START_HOUR = 18; // Set the start hour for the sale.
 const START_MINUTE = 00; // Set the start minute for the sale.
 const END_HOUR = 23; // Set the end hour for the sale.
 const END_MINUTE = 59; // Set the end minute for the sale.
+const METAMASK_ACCOUNT_NUMBER = 1; // Set the account to be used from your metamask wallet list.
 
 let COLLECTION_BASE_URL = '';
 
@@ -84,6 +85,12 @@ async function main() {
         COLLECTION_BASE_URL = "https://opensea.io/assets" ;
     }
 
+    // Switch to specific account on Metamask seed
+    if (METAMASK_ACCOUNT_NUMBER != 0 && METAMASK_ACCOUNT_NUMBER != 1) {
+        metamask.switchAccount(METAMASK_ACCOUNT_NUMBER);
+        console.log(`Updated Metamask account number to ${METAMASK_ACCOUNT_NUMBER}`);
+    }
+        
     // Set your collection URL. The contract address from the account_details.js file will be used.
     COLLECTION_BASE_URL = `${COLLECTION_BASE_URL}/${ACCOUNT_DETAILS.contract_address}/` ;
 


### PR DESCRIPTION
Added a new METAMASK_ACCOUNT_NUMBER field to the utils/opensea/sell_nfts.js script. This will allow users to choose a different wallet after signing into Metamask within the automation script.