### PR TITLE
Opensea Cancel On Sale NFTs Script Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If you would like to support my NFT collection, please take a look at the below.
      - [UploadMetas_Directory Command](#uploadmetas_directory-command)
 
 - [Opensea Commands](#opensea-commands)
+     - [Cancel_On_Sale_Nfts Command](#cancel_on_sale_nfts-command)
      - [Refresh_Metadata Command](#refresh_metadata-command)
      - [Sell_Nfts Command](#sell_nfts-command)
 
@@ -202,9 +203,10 @@ If you would like to support my NFT collection, please take a look at the below.
 ## UPDATES & FIXES
 
 
-### Added Opensea Selling Script
+### Added Opensea Selling Scripts
 Added a new script `utils/opensea/sell_nfts.js` that will allow users to sell NFTs between two edition numbers (inclusive) to be put up for sale if the user owns the NFTs. This functionality uses Puppeteer and Chainsafe's Dappeteer, so please use at your own discretion as you will need to make use of your seed phrase for this functionality to work. [Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42), [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47) and [Feature - Opensea Polygon Script To Auto Sell NFTs Added Metamask Account Number](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/49)
 
+Added a new script `utils/opensea/cancel_on_sale_nfts.js` that will allow users to remove NFTs that they own from being on sale between two edition numbers (inclusive). This functionality uses Puppeteer and Chainsafe's Dappeteer, so please use at your own discretion as you will need to make use of your seed phrase for this functionality to work. [Feature - Cancel NFTs On Sale On Opensea](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/52)
 
 ### Added Start Collection Edition Setting
 Users can now set at which edition number the collection creation process should start add. The `startCollectionEditionFrom` setting can be found in the `constants/nft_details.js` file.
@@ -508,13 +510,24 @@ Use the  `Opensea - Refresh_Metadata Command` below to start the refresh of meta
 
 
 ### 18. Sell NFTS On Opensea
+**Selling NFTs**
 Go to the utils/opensea/sell_nfts.js file and update the `START_EDITION`, `END_EDITION`, `NFT_PRICE`, `DROPDOWN_OPTION`, `DATE_PICK_SKIP`, `START_HOUR`, `START_MINUTE`, `END_HOUR`, `END_MINUTE` fields. Optionally, users can also update the `METAMASK_ACCOUNT_NUMBER` and `seed` fields. Please make sure that the contract address that you are trying sell NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file (also ensure that your `METAMASK_ACCOUNT_NUMBER` is mapped correctly to the `contract_address` value on your Metamask dropdown list) as well as that the `chain` value is correct for the specific contract address.
 
 Use the  `Opensea - Sell_Nfts Command` below to start the putting each NFT edition up for sale between your start and end editions for the given price.
 
-[Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42), [Feature - Opensea Polygon Script To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47) and [Feature - Opensea Polygon Script To Auto Sell NFTs Added Metamask Account Number](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/49)
+**Cancel On Sale NFTs**
+Go to the utils/opensea/cancel_on_sale_nfts.js file and update the `START_EDITION` and `END_EDITION` fields. Optionally, users can also update the `METAMASK_ACCOUNT_NUMBER` and `seed` fields. Please make sure that the contract address that you are trying cancel the sale of NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file (also ensure that your `METAMASK_ACCOUNT_NUMBER` is mapped correctly to the `contract_address` value on your Metamask dropdown list) as well as that the `chain` value is correct for the specific contract address.
 
-**Please read the warning very carefully within the the sell_nfts.js file with regards to the seed field.**
+Use the  `Opensea - Cancel_On_Sale_Nfts Command` below to start the removing each NFT edition from being on sale between your start and end editions.
+
+
+**Features:**
+- [Feature - Opensea Polygon Script To Auto Sell NFTs](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/42)
+- [Feature - Opensea Polygon Script - To Auto Sell NFTs Additional Fields](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/47) 
+- [Feature - Opensea Polygon Script To Auto Sell NFTs Added Metamask Account Number](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/49) 
+- [Feature - Cancel NFTs On Sale On Opensea](https://github.com/thepeanutgalleryandco/create-and-mint-nft-collection/issues/52)
+
+**Please read the warning very carefully within the the sell_nfts.js and cancel_on_sale_nfts.js files with regards to the seed field.**
 **Please note that this script will only work with the Polygon network**
 **Please note this process will be time consuming for large editions.**
 
@@ -662,6 +675,11 @@ Use the following command from the code's root directory.
 
 ## Opensea Commands
 Use the following command from the code's root directory.
+
+### Cancel_On_Sale_Nfts Command
+- node utils/opensea/cancel_on_sale_nfts.js
+- npm run cancel_on_sale_nfts
+
 
 ### Refresh_Metadata Command
 - node utils/opensea/refresh_metadata.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-and-mint-nft-collection",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/dappeteer": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "node index.js",
     "batch_ipfs_metas_migration": "node utils/custom/batch_ipfs_metas_migration.js",
+    "cancel_on_sale_nfts": "node utils/opensea/cancel_on_sale_nfts.js",
     "check_mints": "node utils/custom/check_mints.js",
     "check_mints_batch": "node utils/custom/check_mints_batch.js",
     "create_provenance": "node utils/art_engine/create_provenance.js",

--- a/utils/opensea/cancel_on_sale_nfts.js
+++ b/utils/opensea/cancel_on_sale_nfts.js
@@ -6,15 +6,8 @@ const BASEDIR = process.cwd();
 const { FOLDERS } = require(`${BASEDIR}/constants/folders.js`);
 const { ACCOUNT_DETAILS } = require(`${FOLDERS.constantsDir}/account_details.js`);
 
-const START_EDITION = 1; // Set the start edition of the collection where you want to start selling NFTs from.
-const END_EDITION = 1; // Set the end edition of the collection where you want to stop selling NFTs at.
-const NFT_PRICE = 0.002; // Set the price that will be given to each NFT between START_EDITION and END_EDITION.
-const DROPDOWN_OPTION = 0; // Set the dropdown option to setup the date picker. Leave at 0 to keep the default sell timeframe. Do not add more options than what there is in the Opensea list. Do not count the default item in the list.
-const DATE_PICK_SKIP = 7; // Set the tabs between the date picker drop down and the time. This value should be set between 6, 7 and 8. Please check the comment where this variable is used for more information.
-const START_HOUR = 18; // Set the start hour for the sale.
-const START_MINUTE = 00; // Set the start minute for the sale.
-const END_HOUR = 23; // Set the end hour for the sale.
-const END_MINUTE = 59; // Set the end minute for the sale.
+const START_EDITION = 1; // Set the start edition of the collection where you want to start cancelling NFTs from.
+const END_EDITION = 1; // Set the end edition of the collection where you want to stop cancelling NFTs at.
 const METAMASK_ACCOUNT_NUMBER = 1; // Set the account to be used from your metamask wallet list.
 
 let COLLECTION_BASE_URL = '';
@@ -90,11 +83,11 @@ async function main() {
         metamask.switchAccount(METAMASK_ACCOUNT_NUMBER);
         console.log(`Updated Metamask account number to ${METAMASK_ACCOUNT_NUMBER}`);
     }
-        
+
     // Set your collection URL. The contract address from the account_details.js file will be used.
     COLLECTION_BASE_URL = `${COLLECTION_BASE_URL}/${ACCOUNT_DETAILS.contract_address}/` ;
 
-    console.log("Starting with putting collection items on sale on Opensea - " + COLLECTION_BASE_URL);
+    console.log("Starting with removing collection items from being on sale on Opensea - " + COLLECTION_BASE_URL);
     
     // Create a new tab and launch opensea.io, to the account page
     const page = await browser.newPage();
@@ -121,7 +114,7 @@ async function main() {
     // Loop from the start edition up until the end edition that has been set. Both values are inclusive.
     for (let i = START_EDITION; i <= END_EDITION; i++) {    
         try {
-            console.log(`Starting to put edition on sale: ${i}`);
+            console.log(`Starting to remove sale from edition: ${i}`);
 
             // Set the website URL of the NFT edition
             const url = COLLECTION_BASE_URL + i.toString();
@@ -129,57 +122,15 @@ async function main() {
             // Open the URL on the new tab that got created
             await page.goto(url, { waitUntil: "networkidle0" });
 
-            // Look for a button containing Sell on the page
-            const sellElements = await page.$x("//a[contains(., 'Sell')]");
-            await sellElements[0].click() ;
+            // Look for a button containing Cancel on the page
+            const cancelElements = await page.$x("//button[contains(., 'Cancel')]");
+            await cancelElements[0].click() ;
+            await page.waitForTimeout(3000);
 
-            // Go to the price input box and enter the price
-            await page.waitForSelector('input[name=price]');
-            await page.type('input[name=price]', `${NFT_PRICE}`, {delay: 15});
-
-            // If drop down option is left at 0, then the default date, start and end hour will be used and will skip to the putting the item on sale.
-            // If drop down is populated with a positive number in the list, then navigate to that list item and choose it and also set the start date, end date and time
-            if (DROPDOWN_OPTION > 0) {
-
-                // Navigate to the date picker
-                for (j=0; j < 3; j++) {
-                    await page.keyboard.press('Tab', { page }); // navigate to button
-                }
-                
-                // Navigate to drop down option and choose it
-                for (j=0; j < DROPDOWN_OPTION; j++) {
-                    await page.keyboard.press('Tab', { page }); // navigate to button
-                }
-                await page.keyboard.press('Space', { page }); // hit space button
-
-                /* Go to the time picker
-                    Please note that sometimes, the date picker will be out by a few presses, depending on the date that you are running the script on.
-                    This happens when you are for example in a month of 31 days, and you are trying to go to a month that do not have 31 days
-                    If you face this scenario, simply change the DATE_PICK_SKIP value to the right amount of tabs that is needed from 
-                    choosing the list item on the dropdown. You simply press the tab button after choosing the drop down item until you get to the time
-                    picker. Count the number of tabs required and enter that amount at DATE_PiCK_SKIP at the top of the file. The value is usually between 
-                    6, 7 and 8, but might need some tweaking.
-                */
-                for (j=0; j < DATE_PICK_SKIP; j++) {
-                    await page.keyboard.press('Tab', { page }); // navigate to button
-                }
-    
-                // Enter start time and end time
-                await page.keyboard.type(`${START_HOUR}`, {delay: 15});
-                await page.keyboard.type(`${START_MINUTE}`, {delay: 15});
-                await page.keyboard.press('Tab', { page }); // navigate to button
-                await page.keyboard.type(`${END_HOUR}`, {delay: 15});
-                await page.keyboard.type(`${END_MINUTE}`, {delay: 15});
-    
-                // Exit date picker
-                await page.keyboard.press('Tab', { page }); // navigate to button
-            }
+            // Go to the confirm button and click it
+            await page.keyboard.press('Tab', { page }); // navigate to button
+            await page.keyboard.type('\n'); // hit enter
             
-            // Go to the submit button and click it
-            await page.waitForSelector('button[type=submit]');
-            await page.click('button[type=submit]');
-            await page.waitForTimeout(2000);
-
             // Go to the sign button and click it
             await page.focus('div[aria-hidden="false"]');
             
@@ -192,12 +143,12 @@ async function main() {
             await page.bringToFront();
             await page.waitForTimeout(2000);
 
-            console.log(`Edition successfully put on sale: ${i} , URL: ${url}`);
+            console.log(`Edition successfully removed from being on sale: ${i} , URL: ${url}`);
 
         } catch (error) {
 
             // If any issues come up, then log the error and continue to the next edition
-            console.log(`Error ${error} when attempting to put edition on sale: ${i}`);
+            console.log(`Error ${error} when attempting to remove edition from sale: ${i}`);
 
             // Bring the main tab into view
             await page.bringToFront();


### PR DESCRIPTION
Added a new script that will allow users to remove their NFTs from being on sale like when they would like to change their pricing strategy or simply stop selling for a period of time.

Users should update the START_EDITION and END_EDITION fields before running the script. Also check the README on how to use this script.