### PR TITLE
Reworked Selling Scripts To Work With Private Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,13 +512,13 @@ Use the  `Opensea - Refresh_Metadata Command` below to start the refresh of meta
 ### 18. Sell NFTS On Opensea
 **Selling NFTs**
 
-Go to the utils/opensea/sell_nfts.js file and update the `START_EDITION`, `END_EDITION`, `NFT_PRICE`, `DROPDOWN_OPTION`, `DATE_PICK_SKIP`, `START_HOUR`, `START_MINUTE`, `END_HOUR`, `END_MINUTE` fields. Optionally, users can also update the `METAMASK_ACCOUNT_NUMBER` and `seed` fields. Please make sure that the contract address that you are trying sell NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file (also ensure that your `METAMASK_ACCOUNT_NUMBER` is mapped correctly to the `contract_address` value on your Metamask dropdown list) as well as that the `chain` value is correct for the specific contract address.
+Go to the utils/opensea/sell_nfts.js file and update the `START_EDITION`, `END_EDITION`, `NFT_PRICE`, `DROPDOWN_OPTION`, `DATE_PICK_SKIP`, `START_HOUR`, `START_MINUTE`, `END_HOUR`, `END_MINUTE` and `walletPrivateKey` fields. Please make sure that the contract address that you are trying sell NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file as well as that the `chain` value is correct for the specific contract address.
 
 Use the  `Opensea - Sell_Nfts Command` below to start the putting each NFT edition up for sale between your start and end editions for the given price.
 
 **Cancel On Sale NFTs**
 
-Go to the utils/opensea/cancel_on_sale_nfts.js file and update the `START_EDITION` and `END_EDITION` fields. Optionally, users can also update the `METAMASK_ACCOUNT_NUMBER` and `seed` fields. Please make sure that the contract address that you are trying cancel the sale of NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file (also ensure that your `METAMASK_ACCOUNT_NUMBER` is mapped correctly to the `contract_address` value on your Metamask dropdown list) as well as that the `chain` value is correct for the specific contract address.
+Go to the utils/opensea/cancel_on_sale_nfts.js file and update the `START_EDITION`, `END_EDITION` and `walletPrivateKey` fields. Please make sure that the contract address that you are trying cancel the sale of NFTs for has been set in the `contract_address` field in the `constants/account_details.js` file as well as that the `chain` value is correct for the specific contract address.
 
 Use the  `Opensea - Cancel_On_Sale_Nfts Command` below to start the removing each NFT edition from being on sale between your start and end editions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-and-mint-nft-collection",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/dappeteer": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-and-mint-nft-collection",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Source code to create and mint generative art via NFTPort API. Special thanks to codeSTACKr and Hashlips for their source codebase.",
   "main": "index.js",
   "bin": "index.js",

--- a/utils/opensea/cancel_on_sale_nfts.js
+++ b/utils/opensea/cancel_on_sale_nfts.js
@@ -8,7 +8,33 @@ const { ACCOUNT_DETAILS } = require(`${FOLDERS.constantsDir}/account_details.js`
 
 const START_EDITION = 1; // Set the start edition of the collection where you want to start cancelling NFTs from.
 const END_EDITION = 1; // Set the end edition of the collection where you want to stop cancelling NFTs at.
-const METAMASK_ACCOUNT_NUMBER = 1; // Set the account to be used from your metamask wallet list.
+const walletPrivateKey = ''; // Set the private key of the wallet that you would like to import and use. Upon importing a private key, the imported wallet will automatically be chosen.
+/* 
+Retrieving your wallet private key:
+
+Setup and login to metamask
+1. Go to your metamask
+2. Select the wallet that you would like to make use of from the drop down of accounts.
+3. Click on the settings (three dots)
+4. Choose account details
+5. Choose export private key
+6. Enter metamask password
+7. Copy your private key as the value for your walletPrivateKey field above this section.
+
+Example:
+walletPrivateKey = '8e51i2n3i2oco3o102k3k2k31k2nifn0139r17213k2hhh1i23p142e1o124ao11';
+
+***************************************************************************************************************************************************
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+***************************************************************************************************************************************************
+
+PLEASE DO NOT SHARE THIS WITH ANYONE ELSE AND DO NOT SHARE THIS SCRIPT FILE WITH ANYONE ELSE BEFORE REMOVING YOUR walletPrivateKey value!!!!!!!!!!!!!
+
+***************************************************************************************************************************************************
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+***************************************************************************************************************************************************
+
+*/
 
 let COLLECTION_BASE_URL = '';
 
@@ -28,29 +54,8 @@ async function main() {
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });
     
-    /* 
-    Setup and login to metamask
-    1. Go to your metamask
-    2. Click settings
-    3. Click Security & Privacy
-    4. Enter passphrase
-    5. Copy or write down your seed phrase as you will need to enter it when the script runs.
-    
-    6. 
-    ***************************************************************************************************************************************************
-    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-    ***************************************************************************************************************************************************
-    WHEN RUNNING THE SCRIPT, YOU CAN EITHER MANUALLY ENTER YOUR SEED PHRASE OR YOU REPLACE THE VALUE OF seed: 'test' WITH YOUR SEED PHRASE.
-    IF YOU CHOOSE THE OPTION OF STORING YOUR SEED PHRASE, THEN PLEASE DO NOT SHARE THIS WITH ANYONE ELSE AND DO NOT SHARE THIS SCRIPT FILE WITH ANYONE ELSE 
-    BEFORE REMOVING YOUR SEED PHRASE!!!!!!!!!!!!!
-    ***************************************************************************************************************************************************
-    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-    ***************************************************************************************************************************************************
-    
-    */
+    // Create new metamask account and sign in to metamask. A random seed phrase gets used.
     const metamask = await dappeteer.setupMetamask(browser, {
-      seed: 'test',
-      password: '1234567890',
       hideSeed: true
     });
     
@@ -78,11 +83,11 @@ async function main() {
         COLLECTION_BASE_URL = "https://opensea.io/assets" ;
     }
 
-    // Switch to specific account on Metamask seed
-    if (METAMASK_ACCOUNT_NUMBER != 0 && METAMASK_ACCOUNT_NUMBER != 1) {
-        metamask.switchAccount(METAMASK_ACCOUNT_NUMBER);
-        console.log(`Updated Metamask account number to ${METAMASK_ACCOUNT_NUMBER}`);
-    }
+    // Import private key if walletPrivateKey is populated
+    if (walletPrivateKey) {
+        await metamask.importPK(walletPrivateKey);    
+        console.log(`Imported wallet private key`);
+    }      
 
     // Set your collection URL. The contract address from the account_details.js file will be used.
     COLLECTION_BASE_URL = `${COLLECTION_BASE_URL}/${ACCOUNT_DETAILS.contract_address}/` ;

--- a/utils/opensea/sell_nfts.js
+++ b/utils/opensea/sell_nfts.js
@@ -15,7 +15,33 @@ const START_HOUR = 18; // Set the start hour for the sale.
 const START_MINUTE = 00; // Set the start minute for the sale.
 const END_HOUR = 23; // Set the end hour for the sale.
 const END_MINUTE = 59; // Set the end minute for the sale.
-const METAMASK_ACCOUNT_NUMBER = 1; // Set the account to be used from your metamask wallet list.
+const walletPrivateKey = ''; // Set the private key of the wallet that you would like to import and use. Upon importing a private key, the imported wallet will automatically be chosen.
+/* 
+Retrieving your wallet private key:
+
+Setup and login to metamask
+1. Go to your metamask
+2. Select the wallet that you would like to make use of from the drop down of accounts.
+3. Click on the settings (three dots)
+4. Choose account details
+5. Choose export private key
+6. Enter metamask password
+7. Copy your private key as the value for your walletPrivateKey field above this section.
+
+Example:
+walletPrivateKey = '8e51i2n3i2oco3o102k3k2k31k2nifn0139r17213k2hhh1i23p142e1o124ao11';
+
+***************************************************************************************************************************************************
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+***************************************************************************************************************************************************
+
+PLEASE DO NOT SHARE THIS WITH ANYONE ELSE AND DO NOT SHARE THIS SCRIPT FILE WITH ANYONE ELSE BEFORE REMOVING YOUR walletPrivateKey value!!!!!!!!!!!!!
+
+***************************************************************************************************************************************************
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+***************************************************************************************************************************************************
+
+*/
 
 let COLLECTION_BASE_URL = '';
 
@@ -35,29 +61,8 @@ async function main() {
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });
     
-    /* 
-    Setup and login to metamask
-    1. Go to your metamask
-    2. Click settings
-    3. Click Security & Privacy
-    4. Enter passphrase
-    5. Copy or write down your seed phrase as you will need to enter it when the script runs.
-    
-    6. 
-    ***************************************************************************************************************************************************
-    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-    ***************************************************************************************************************************************************
-    WHEN RUNNING THE SCRIPT, YOU CAN EITHER MANUALLY ENTER YOUR SEED PHRASE OR YOU REPLACE THE VALUE OF seed: 'test' WITH YOUR SEED PHRASE.
-    IF YOU CHOOSE THE OPTION OF STORING YOUR SEED PHRASE, THEN PLEASE DO NOT SHARE THIS WITH ANYONE ELSE AND DO NOT SHARE THIS SCRIPT FILE WITH ANYONE ELSE 
-    BEFORE REMOVING YOUR SEED PHRASE!!!!!!!!!!!!!
-    ***************************************************************************************************************************************************
-    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-    ***************************************************************************************************************************************************
-    
-    */
+    // Create new metamask account and sign in to metamask. A random seed phrase gets used.
     const metamask = await dappeteer.setupMetamask(browser, {
-      seed: 'test',
-      password: '1234567890',
       hideSeed: true
     });
     
@@ -85,11 +90,11 @@ async function main() {
         COLLECTION_BASE_URL = "https://opensea.io/assets" ;
     }
 
-    // Switch to specific account on Metamask seed
-    if (METAMASK_ACCOUNT_NUMBER != 0 && METAMASK_ACCOUNT_NUMBER != 1) {
-        metamask.switchAccount(METAMASK_ACCOUNT_NUMBER);
-        console.log(`Updated Metamask account number to ${METAMASK_ACCOUNT_NUMBER}`);
-    }
+    // Import private key if walletPrivateKey is populated
+    if (walletPrivateKey) {
+        await metamask.importPK(walletPrivateKey);    
+        console.log(`Imported wallet private key`);
+    }  
         
     // Set your collection URL. The contract address from the account_details.js file will be used.
     COLLECTION_BASE_URL = `${COLLECTION_BASE_URL}/${ACCOUNT_DETAILS.contract_address}/` ;


### PR DESCRIPTION
Reworked Selling Scripts To Work With Private Key Instead Of Seed Phrase And Account Numbers.

To make use of the selling scripts, users can simply populate the walletPrivateKey field and then their specific wallet will be imported and used for the selling functionality.

The METAMASK_ACCOUNT_NUMBER, seed and password fields were removed from the scripts.